### PR TITLE
Fix overzealous replacement of "in us"

### DIFF
--- a/_data/transform.py
+++ b/_data/transform.py
@@ -27,7 +27,7 @@ for key, value in raw.items():
     if len(bible[book][chapter]) == 0 or value.startswith('#'):
         bible[book][chapter].append({})
     val = rep(value, "^# ", "")
-    val = rep(val, "in us", "among us")
+    val = rep(val, "\\bin us\\b", "among us")
     val = rep(val, "\\bsin\\b", "cringe")
     val = rep(val, "\\bsins\\b", "cringes")
     val = rep(val, "\\bsinner\\b", "cringer")


### PR DESCRIPTION
In [Luke 24:32](https://galenguyer.github.io/pog-james-bible/luke#24v32) "within us" is replaced by "withamong us", which is excellent but also probably unintentional.